### PR TITLE
Automate visual regression tests for all routes

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,38 @@
+name: Visual Tests (Playwright)
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  visual:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests (visual)
+        run: npm run test:visual:all
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore
+

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     
     "test:coverage": "ng test --watch=false --browsers=ChromeHeadless --code-coverage",
     "test:visual": "playwright test --config=playwright.config.ts",
+    "test:visual:all": "playwright test --config=playwright.config.ts",
+    "test:visual:report": "playwright show-report",
     "test:visual:all:premium": "npm run test:ux:premium:consistency:all",
     "test:visual:responsive:premium": "npm run test:responsive:premium:mobile && npm run test:responsive:premium:tablet && npm run test:responsive:premium:desktop",
     "test:performance:premium": "npm run test:perf:lighthouse",


### PR DESCRIPTION
Add Playwright visual test scripts and a GitHub Actions workflow to automate visual testing and reporting.

This PR introduces new `npm` scripts for running the full Playwright visual test suite (`test:visual:all`) and viewing its HTML report (`test:visual:report`). It also sets up a GitHub Actions workflow to automatically execute these visual tests on push/PR to `main`/`master` branches and upload the `playwright-report` as an artifact, ensuring continuous visual regression detection for all routes, including the `/onboarding` flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-f983d7f3-657f-4c72-9f27-5cafa3446eaa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f983d7f3-657f-4c72-9f27-5cafa3446eaa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

