### PR TITLE
Refactor to minimal dark theme tokens

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -15,10 +15,10 @@
 /* Essential styles for Phosphor Icons integration */
 
 /* Premium FinTech Theme - Lazy loaded */
-@import 'styles/theme-premium.css';
+/* @import removed: styles/theme-premium.css */
 
 /* Premium Animations - Deferred for better performance */
-@import 'styles/premium-animations.scss';
+/* @import removed: styles/premium-animations.scss */
 
 /* ===== CSS VARIABLES (Common tokens) ===== */
 @import 'styles/_tokens.scss';

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -1,11 +1,21 @@
 :root {
   --brand: #06b6d4;
-  --bg-dark: #0b0f14;        /* fondo base */
-  --surface-dark: #1f2937;   /* cards, inputs */
-  --border-dark: #374151;    /* bordes */
-  --text-primary: #f3f4f6;   /* texto principal */
-  --text-secondary: #9ca3af; /* texto secundario */
-  --success: #10b981;
-  --warning: #f59e0b;
-  --error: #ef4444;
+  --bg-dark: #0b0f14;
+  --surface-dark: #1f2937;
+  --border-dark: #374151;
+  --text-light: #f3f4f6;
+  --text-1: #0f172a;
+  --text-2: #6b7280;
+  --green: #16a34a;
+  --yellow: #ca8a04;
+  --red: #dc2626;
+}
+
+/* Compat aliases – eliminar en PR#292-b */
+:root {
+  --text-primary: var(--text-light);
+  --text-secondary: var(--text-2);
+  --success: var(--green);
+  --warning: var(--yellow);
+  --error: var(--red);
 }


### PR DESCRIPTION
Remove global premium styles and tokens, replacing them with a Minimal Dark set and adding compat aliases to avoid breaking existing tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-bec742ac-1372-451b-b76c-99f3277f50fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bec742ac-1372-451b-b76c-99f3277f50fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

