### PR TITLE
Refactor documentos module to minimal dark style

### DIFF
--- a/src/app/components/pages/documentos/documentos.component.html
+++ b/src/app/components/pages/documentos/documentos.component.html
@@ -1,30 +1,26 @@
-<section class="ui-card dark:bg-slate-900 dark:text-slate-100">
+<section class="ui-card">
 	<h2 class="text-sm font-semibold mb-3">Carga de Documentos</h2>
 
-	<input type="file" (change)="onFileSelected($event)" data-cy="doc-upload" class="block w-full text-sm mb-3" />
+	<input type="file" (change)="onFileSelected($event)" data-cy="doc-upload" class="ui-input mb-3" />
 
 	<button (click)="subirDocumento()" data-cy="doc-submit" class="ui-btn ui-btn-primary">
 		Subir
 	</button>
 
 	<div
-		class="mt-3 text-sm"
-		[ngClass]="{
-			'text-slate-500': estado==='Pendiente',
-			'text-green-600': estado==='Validado',
-			'text-red-600': estado==='Error'
-		}"
+		class="mt-3 text-sm ocr-status"
+		[attr.data-status]="estado"
 		data-cy="doc-status"
 	>
 		{{ estado }}
 	</div>
 </section>
 
-<section class="ui-card mt-6 dark:bg-slate-900 dark:text-slate-100">
+<section class="ui-card mt-6">
 	<h2 class="text-sm font-semibold mb-3">Documentos cargados</h2>
-	<table class="w-full text-sm border-collapse" data-cy="doc-table">
+	<table class="w-full text-sm border-collapse doc-table" data-cy="doc-table">
 		<thead>
-			<tr class="text-slate-500 border-b dark:border-slate-700">
+			<tr>
 				<th class="text-left py-2">Nombre</th>
 				<th class="text-left py-2">Estado</th>
 				<th class="text-left py-2">Última actualización</th>
@@ -36,12 +32,13 @@
 				<td class="py-2">Pendiente</td>
 				<td class="py-2">-</td>
 			</tr>
-			<tr *ngFor="let doc of documentos" class="border-b dark:border-slate-700">
+			<tr *ngFor="let doc of documentos">
 				<td class="py-2">{{ doc.nombre }}</td>
 				<td class="py-2">{{ doc.estado }}</td>
 				<td class="py-2">{{ doc.fecha }}</td>
 			</tr>
 		</tbody>
 	</table>
+
 </section>
 

--- a/src/app/components/pages/documentos/documentos.component.scss
+++ b/src/app/components/pages/documentos/documentos.component.scss
@@ -1,4 +1,38 @@
 .loader-row {
-	@apply text-slate-500 dark:text-slate-100;
+	color: var(--text-2);
+}
+
+.ocr-status {
+	color: var(--text-2);
+	&[data-status="Pendiente"] {
+		color: var(--yellow);
+	}
+	&[data-status="Validado"] {
+		color: var(--green);
+	}
+	&[data-status="Error"] {
+		color: var(--red);
+	}
+}
+
+.doc-table {
+	width: 100%;
+	border-collapse: collapse;
+	color: var(--text-light);
+
+	thead tr {
+		color: var(--text-2);
+		border-bottom: 1px solid var(--border-dark);
+	}
+
+	th,
+	td {
+		padding: 0.5rem 0;
+		text-align: left;
+	}
+
+	tbody tr {
+		border-bottom: 1px solid var(--border-dark);
+	}
 }
 


### PR DESCRIPTION
Refactor the Documentos module UI to remove Premium styling and adopt a Minimal Dark (OpenAI-style) using `ui-*` components and theme tokens.

---
<a href="https://cursor.com/background-agent?bcId=bc-fdb023e5-dc36-4c46-9884-2671bd0d2535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fdb023e5-dc36-4c46-9884-2671bd0d2535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

