### PR TITLE
Prevent workflow job bottlenecks

### DIFF
--- a/.github/workflows/kill.yml
+++ b/.github/workflows/kill.yml
@@ -1,0 +1,14 @@
+name: Kill Running Workflows
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+        with:
+          access_token: ${{ github.token }}
+

--- a/.github/workflows/ui-qa.yml
+++ b/.github/workflows/ui-qa.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: qa-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ui-qa:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a workflow to manually kill all running workflows and configure the QA workflow to auto-cancel previous runs to prevent bottlenecks.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d08102e-29bb-42fd-8bad-caeb157b1a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d08102e-29bb-42fd-8bad-caeb157b1a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

