### PR TITLE
Clean up residual dark mode styles

### DIFF
--- a/scripts/audit-minimal-dark.sh
+++ b/scripts/audit-minimal-dark.sh
@@ -2,13 +2,18 @@
 set -euo pipefail
 
 echo "Audit Minimal Dark - Prohibited patterns in src/:"
-grep -RInE "(bg-gray-|text-gray-|gradient|glass|premium-card|glass-card)" src || true
+if grep -RInE "(bg-gray-|text-gray-|linear-gradient|glass|glass-bg|glass-border|backdrop-filter|premium-card|glass-card|#ffffff|#cbd5e1)" src ; then
+  echo "❌ Found prohibited Minimal Dark patterns."
+  exit 1
+else
+  echo "✅ No prohibited patterns found."
+fi
 
 echo
 echo "Counts:"
 printf "bg-gray-* : %s\n" "$(grep -RIn "bg-gray-" src | wc -l | xargs)"
 printf "text-gray-*: %s\n" "$(grep -RIn "text-gray-" src | wc -l | xargs)"
-printf "gradient  : %s\n" "$(grep -RIn "gradient" src | wc -l | xargs)"
+printf "gradient  : %s\n" "$(grep -RIn "linear-gradient" src | wc -l | xargs)"
 printf "glass     : %s\n" "$(grep -RIn "glass" src | wc -l | xargs)"
 printf "premium   : %s\n" "$(grep -RIn "premium-card" src | wc -l | xargs)"
 

--- a/src/app/components/auth/login/login.component.ts
+++ b/src/app/components/auth/login/login.component.ts
@@ -145,7 +145,7 @@ import { Router } from '@angular/router';
       display: flex;
       align-items: center;
       justify-content: center;
-      background: var(--bg-gray-950);
+      background: var(--bg-dark);
       position: relative;
       overflow: hidden;
     }
@@ -194,14 +194,8 @@ import { Router } from '@angular/router';
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(
-        45deg, 
-        transparent 45%, 
-        var(--primary-cyan-800) 46%, 
-        var(--primary-cyan-800) 47%, 
-        transparent 48%
-      );
-      animation: slide-lines 8s linear infinite;
+      background: repeating-linear-gradient(45deg, transparent, transparent 20px, var(--border-dark) 20px, var(--border-dark) 22px);
+      animation: slide-lines 12s linear infinite;
     }
 
     @keyframes slide-lines {
@@ -211,10 +205,10 @@ import { Router } from '@angular/router';
 
     /* ===== COMMAND CENTER CARD ===== */
     .command-center-card {
-      background: var(--glass-bg);
-      border: 1px solid var(--glass-border);
-      backdrop-filter: var(--glass-backdrop);
-      -webkit-backdrop-filter: var(--glass-backdrop);
+      background: var(--surface-dark);
+      border: 1px solid var(--border-dark);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
       border-radius: 24px;
       padding: 48px;
       width: 100%;
@@ -232,7 +226,7 @@ import { Router } from '@angular/router';
       left: -1px;
       right: -1px;
       bottom: -1px;
-      background: linear-gradient(135deg, var(--primary-cyan-400), transparent, var(--accent-amber-500));
+      background: var(--border-dark);
       border-radius: 24px;
       z-index: -1;
       opacity: 0.3;
@@ -275,7 +269,7 @@ import { Router } from '@angular/router';
     }
 
     .brand-subtitle {
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       font-size: 1.1rem;
       font-weight: 500;
       margin: 0;
@@ -317,7 +311,7 @@ import { Router } from '@angular/router';
       transform: translateY(-50%);
       background: none;
       border: none;
-      color: var(--bg-gray-400);
+      color: var(--text-2);
       font-size: 1.2rem;
       cursor: pointer;
       padding: 8px;
@@ -358,7 +352,7 @@ import { Router } from '@angular/router';
       gap: 10px;
       cursor: pointer;
       font-size: 0.9rem;
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       user-select: none;
     }
 
@@ -460,7 +454,7 @@ import { Router } from '@angular/router';
 
     .register-text {
       margin: 0;
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       font-size: 0.95rem;
     }
 
@@ -528,7 +522,7 @@ import { Router } from '@angular/router';
     }
 
     .credential-label {
-      color: var(--bg-gray-400);
+      color: var(--text-2);
       font-size: 0.9rem;
       font-weight: 500;
     }

--- a/src/app/components/pages/configuracion/configuracion.component.scss
+++ b/src/app/components/pages/configuracion/configuracion.component.scss
@@ -4,8 +4,8 @@
 
 .ui-card {
   border-radius: 0.5rem;
-  border: 1px solid #e2e8f0;
-  background: #ffffff;
+  border: 1px solid var(--border-dark);
+  background: var(--surface-dark);
   padding: 1rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
@@ -13,17 +13,17 @@
 .ui-input {
   width: 100%;
   border-radius: 0.375rem;
-  border: 1px solid #cbd5e1;
-  background: #ffffff;
+  border: 1px solid var(--border-dark);
+  background: var(--bg-dark);
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
-  color: #0f172a;
+  color: var(--text-light);
   outline: none;
 }
 
 .ui-input:focus {
-  border-color: #94a3b8;
-  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.4);
+  border-color: var(--border-dark);
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--border-dark) 40%, transparent);
 }
 
 .ui-btn {
@@ -31,9 +31,9 @@
   align-items: center;
   justify-content: center;
   border-radius: 0.375rem;
-  border: 1px solid #cbd5e1;
-  background: #f1f5f9;
-  color: #0f172a;
+  border: 1px solid var(--border-dark);
+  background: var(--bg-dark);
+  color: var(--text-light);
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
   font-weight: 500;
@@ -41,11 +41,11 @@
 }
 
 .ui-btn:hover {
-  background: #e2e8f0;
+  background: color-mix(in oklab, var(--surface-dark) 70%, transparent);
 }
 
 .ui-btn-primary {
   background: var(--brand);
-  color: #ffffff;
+  color: var(--text-light);
   border-color: transparent;
 }

--- a/src/app/components/pages/simulador/tanda-colectiva/tanda-colectiva.component.ts
+++ b/src/app/components/pages/simulador/tanda-colectiva/tanda-colectiva.component.ts
@@ -57,7 +57,7 @@ interface KpiData {
 
       <!-- Resumen KPIs -->
       <div class="ui-card">
-        <h2 class="text-lg font-semibold text-gray-800 mb-3">Resumen</h2>
+        <h2 class="text-lg font-semibold text-[var(--text-light)] mb-3">Resumen</h2>
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
           <div class="ui-card">
             <div class="text-purple-600 text-xs">Mensualidad Grupo</div>
@@ -77,7 +77,7 @@ interface KpiData {
       <div class="grid-aside">
         <!-- Configuration Panel -->
         <div class="ui-card">
-          <h2 class="text-xl font-semibold text-gray-800 mb-6 flex items-center">
+          <h2 class="text-xl font-semibold text-[var(--text-light)] mb-6 flex items-center">
             <span class="bg-purple-500 text-white rounded-full w-8 h-8 flex items-center justify-center text-sm font-bold mr-3">1</span>
             Unidad
           </h2>
@@ -85,7 +85,7 @@ interface KpiData {
           <form [formGroup]="configForm" class="space-y-6">
             <!-- Member Count -->
             <div class="space-y-2">
-              <label class="block text-sm font-medium text-gray-700">
+              <label class="block text-sm font-medium text-[var(--text-2)]">
                 Número de Miembros del Grupo *
               </label>
               <input
@@ -97,7 +97,7 @@ interface KpiData {
                 max="50"
                 step="1"
               />
-              <div class="flex justify-between text-xs text-gray-500">
+              <div class="flex justify-between text-xs text-[var(--text-2)]">
                 <span>Mínimo: 5 miembros</span>
                 <span>Máximo: 50 miembros</span>
               </div>
@@ -111,11 +111,11 @@ interface KpiData {
 
             <!-- Unit Price -->
             <div class="space-y-2">
-              <label class="block text-sm font-medium text-gray-700">
+              <label class="block text-sm font-medium text-[var(--text-2)]">
                 Precio de la Unidad *
               </label>
               <div class="relative">
-                <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500">$</span>
+                <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-[var(--text-2)]">$</span>
                 <input
                   type="number"
                   formControlName="unitPrice"
@@ -125,7 +125,7 @@ interface KpiData {
                   step="1000"
                 />
               </div>
-              <p class="text-xs text-gray-500">Precio base de la vagoneta Estado de México</p>
+              <p class="text-xs text-[var(--text-2)]">Precio base de la vagoneta Estado de México</p>
               <div *ngIf="configForm.get('unitPrice')?.errors?.['required']" 
                    class="text-red-500 text-sm">El precio de la unidad es obligatorio</div>
               <div *ngIf="configForm.get('unitPrice')?.errors?.['min']" 
@@ -134,7 +134,7 @@ interface KpiData {
 
             <!-- Average Consumption -->
             <div class="space-y-2">
-              <label class="block text-sm font-medium text-gray-700">
+              <label class="block text-sm font-medium text-[var(--text-2)]">
                 Consumo Promedio por Miembro *
               </label>
               <div class="relative">
@@ -146,9 +146,9 @@ interface KpiData {
                   min="200"
                   step="50"
                 />
-                <span class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500">litros/mes</span>
+                <span class="absolute right-3 top-1/2 transform -translate-y-1/2 text-[var(--text-2)]">litros/mes</span>
               </div>
-              <p class="text-xs text-gray-500">Consumo mensual promedio esperado por cada miembro</p>
+              <p class="text-xs text-[var(--text-2)]">Consumo mensual promedio esperado por cada miembro</p>
               <div *ngIf="configForm.get('avgConsumption')?.errors?.['required']" 
                    class="text-red-500 text-sm">El consumo promedio es obligatorio</div>
               <div *ngIf="configForm.get('avgConsumption')?.errors?.['min']" 
@@ -157,11 +157,11 @@ interface KpiData {
 
             <!-- Overprice Per Liter -->
             <div class="space-y-2">
-              <label class="block text-sm font-medium text-gray-700">
+              <label class="block text-sm font-medium text-[var(--text-2)]">
                 Sobreprecio por Litro *
               </label>
               <div class="relative">
-                <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500">$</span>
+                <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-[var(--text-2)]">$</span>
                 <input
                   type="number"
                   formControlName="overpricePerLiter"
@@ -194,14 +194,14 @@ interface KpiData {
                   step="100"
                 />
               </div>
-              <p class="text-xs text-gray-500">Aportación mensual adicional que cada miembro puede hacer</p>
+              <p class="text-xs text-[var(--text-2)]">Aportación mensual adicional que cada miembro puede hacer</p>
               <div *ngIf="configForm.get('voluntaryMonthly')?.errors?.['min']" 
                    class="text-red-500 text-sm">No puede ser negativo</div>
             </div>
 
             <!-- What-If Events Builder (Advanced Mode Only) -->
             <div *ngIf="currentViewMode === 'advanced'" class="space-y-4 pt-6 border-t border-[var(--border-dark)]">
-              <h3 class="text-lg font-semibold text-gray-800 flex items-center">
+              <h3 class="text-lg font-semibold text-[var(--text-light)] flex items-center">
                 <span class="bg-orange-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold mr-2">?</span>
                 What-If Events Builder
               </h3>
@@ -213,7 +213,7 @@ interface KpiData {
                 
                 <div class="grid grid-cols-2 gap-3">
                   <div>
-                    <label class="block text-xs font-medium text-gray-600 mb-1">Mes</label>
+                    <label class="block text-xs font-medium text-[var(--text-2)] mb-1">Mes</label>
                     <input
                       type="number"
                       [(ngModel)]="newEvent.month"
@@ -225,7 +225,7 @@ interface KpiData {
                   </div>
                   
                   <div>
-                    <label class="block text-xs font-medium text-gray-600 mb-1">Tipo</label>
+                    <label class="block text-xs font-medium text-[var(--text-2)] mb-1">Tipo</label>
                     <select
                       [(ngModel)]="newEvent.type"
                       class="ui-input text-sm"
@@ -236,7 +236,7 @@ interface KpiData {
                   </div>
                   
                   <div>
-                    <label class="block text-xs font-medium text-gray-600 mb-1">Miembro</label>
+                    <label class="block text-xs font-medium text-[var(--text-2)] mb-1">Miembro</label>
                     <select
                       [(ngModel)]="newEvent.memberId"
                       class="ui-input text-sm"
@@ -248,9 +248,9 @@ interface KpiData {
                   </div>
                   
                   <div>
-                    <label class="block text-xs font-medium text-gray-600 mb-1">Monto</label>
+                    <label class="block text-xs font-medium text-[var(--text-2)] mb-1">Monto</label>
                     <div class="relative">
-                      <span class="absolute left-2 top-1/2 transform -translate-y-1/2 text-gray-500 text-sm">$</span>
+                      <span class="absolute left-2 top-1/2 transform -translate-y-1/2 text-[var(--text-2)] text-sm">$</span>
                       <input
                         type="number"
                         [(ngModel)]="newEvent.amount"
@@ -273,7 +273,7 @@ interface KpiData {
 
               <!-- Events List -->
               <div *ngIf="whatIfEvents.length > 0" class="space-y-2">
-                <h4 class="font-medium text-gray-700">Eventos Programados ({{ whatIfEvents.length }})</h4>
+              <h4 class="font-medium text-[var(--text-light)]">Eventos Programados ({{ whatIfEvents.length }})</h4>
                 
               <div class="max-h-32 overflow-y-auto space-y-2">
                   <div 

--- a/src/app/components/shared/client-mode-toggle/client-mode-toggle.component.ts
+++ b/src/app/components/shared/client-mode-toggle/client-mode-toggle.component.ts
@@ -63,10 +63,10 @@ export type ViewMode = 'advisor' | 'client';
       display: flex;
       align-items: center;
       gap: 16px;
-      background: var(--glass-bg);
-      border: 1px solid var(--glass-border);
-      backdrop-filter: var(--glass-backdrop);
-      -webkit-backdrop-filter: var(--glass-backdrop);
+      background: var(--surface-dark);
+      border: 1px solid var(--border-dark);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
       padding: 12px 20px;
       border-radius: 16px;
       transition: all 0.3s ease;
@@ -105,7 +105,7 @@ export type ViewMode = 'advisor' | 'client';
     }
 
     .mode-text {
-      color: var(--bg-gray-100);
+      color: var(--text-light);
       font-weight: 600;
       font-size: 1rem;
     }
@@ -132,17 +132,17 @@ export type ViewMode = 'advisor' | 'client';
     .toggle-slider {
       width: 60px;
       height: 32px;
-      background: rgba(255, 255, 255, 0.1);
-      border: 1px solid var(--glass-border);
+      background: var(--bg-dark);
+      border: 1px solid var(--border-dark);
       border-radius: 20px;
       position: relative;
       transition: all 0.3s ease;
     }
 
     .toggle-slider.slider-client {
-      background: linear-gradient(135deg, var(--accent-amber-500), var(--accent-amber-600));
-      border-color: var(--accent-amber-400);
-      box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
+      background: var(--bg-dark);
+      border-color: var(--border-dark);
+      box-shadow: none;
     }
 
     .slider-handle {
@@ -151,7 +151,7 @@ export type ViewMode = 'advisor' | 'client';
       left: 2px;
       width: 26px;
       height: 26px;
-      background: linear-gradient(135deg, var(--primary-cyan-400), var(--primary-cyan-500));
+      background: var(--surface-dark);
       border-radius: 50%;
       transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       display: flex;
@@ -162,8 +162,8 @@ export type ViewMode = 'advisor' | 'client';
 
     .slider-client .slider-handle {
       transform: translateX(28px);
-      background: linear-gradient(135deg, var(--bg-gray-950), var(--bg-gray-800));
-      box-shadow: 0 2px 8px rgba(245, 158, 11, 0.3);
+      background: var(--bg-dark);
+      box-shadow: 0 2px 8px rgba(245, 158, 11, 0.2);
     }
 
     .handle-icon {
@@ -172,7 +172,7 @@ export type ViewMode = 'advisor' | 'client';
     }
 
     .toggle-text {
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       font-size: 0.9rem;
       font-weight: 500;
       transition: all 0.3s ease;
@@ -193,7 +193,7 @@ export type ViewMode = 'advisor' | 'client';
 
     .mode-description p {
       margin: 0;
-      color: var(--bg-gray-400);
+      color: var(--text-2);
       font-size: 0.85rem;
       line-height: 1.4;
       transition: all 0.3s ease;
@@ -211,8 +211,8 @@ export type ViewMode = 'advisor' | 'client';
       right: 0;
       bottom: 0;
       background: rgba(3, 7, 18, 0.95);
-      backdrop-filter: blur(8px);
-      -webkit-backdrop-filter: blur(8px);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -246,14 +246,14 @@ export type ViewMode = 'advisor' | 'client';
     }
 
     .transition-title {
-      color: var(--bg-gray-100);
+      color: var(--text-light);
       font-size: 1.8rem;
       font-weight: 700;
       margin: 0 0 12px 0;
     }
 
     .transition-description {
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       font-size: 1rem;
       line-height: 1.5;
       margin: 0 0 32px 0;

--- a/src/app/components/shared/contextual-kpis/contextual-kpis.component.ts
+++ b/src/app/components/shared/contextual-kpis/contextual-kpis.component.ts
@@ -69,14 +69,14 @@ export interface KPIData {
     }
 
     .kpis-title {
-      color: var(--bg-gray-100);
+      color: var(--text-light);
       font-size: 1.5rem;
       font-weight: 700;
       margin: 0;
     }
 
     .kpis-subtitle {
-      color: var(--bg-gray-400);
+      color: var(--text-2);
       font-size: 0.9rem;
       margin: 0;
       font-weight: 500;
@@ -89,10 +89,10 @@ export interface KPIData {
     }
 
     .kpi-card {
-      background: var(--glass-bg);
-      border: 1px solid var(--glass-border);
-      backdrop-filter: var(--glass-backdrop);
-      -webkit-backdrop-filter: var(--glass-backdrop);
+      background: var(--surface-dark);
+      border: 1px solid var(--border-dark);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
       border-radius: 16px;
       padding: 24px;
       position: relative;
@@ -157,8 +157,8 @@ export interface KPIData {
 
     .trend-stable {
       background: rgba(156, 163, 175, 0.1);
-      border: 1px solid var(--bg-gray-500);
-      color: var(--bg-gray-400);
+      border: 1px solid var(--border-dark);
+      color: var(--text-2);
     }
 
     .trend-icon {
@@ -174,35 +174,22 @@ export interface KPIData {
       font-weight: 800;
       line-height: 1;
       margin-bottom: 8px;
-      background: linear-gradient(135deg, var(--bg-gray-100), var(--bg-gray-300));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
+      color: var(--text-light);
     }
 
-    .kpi-primary .kpi-value {
-      background: linear-gradient(135deg, var(--primary-cyan-300), var(--primary-cyan-500));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-    }
+    .kpi-primary .kpi-value { color: var(--text-light); }
 
-    .kpi-accent .kpi-value {
-      background: linear-gradient(135deg, var(--accent-amber-400), var(--accent-amber-600));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-    }
+    .kpi-accent .kpi-value { color: var(--text-light); }
 
     .kpi-title-text {
-      color: var(--bg-gray-200);
+      color: var(--text-2);
       font-size: 1rem;
       font-weight: 600;
       margin-bottom: 4px;
     }
 
     .kpi-subtitle {
-      color: var(--bg-gray-400);
+      color: var(--text-2);
       font-size: 0.85rem;
     }
 
@@ -222,17 +209,11 @@ export interface KPIData {
       border-radius: 0 4px 4px 0;
     }
 
-    .trend-fill-up {
-      background: linear-gradient(90deg, var(--success-500), var(--success-400));
-    }
+    .trend-fill-up { background: var(--success-500); }
 
-    .trend-fill-down {
-      background: linear-gradient(90deg, var(--error-500), var(--error-400));
-    }
+    .trend-fill-down { background: var(--error-500); }
 
-    .trend-fill-stable {
-      background: linear-gradient(90deg, var(--bg-gray-500), var(--bg-gray-400));
-    }
+    .trend-fill-stable { background: var(--border-dark); }
 
     @media (max-width: 768px) {
       .kpis-grid {

--- a/src/app/components/shared/human-activity-feed/human-activity-feed.component.ts
+++ b/src/app/components/shared/human-activity-feed/human-activity-feed.component.ts
@@ -141,10 +141,10 @@ export interface ActivityItem {
   `,
   styles: [`
     .activity-feed-container {
-      background: var(--glass-bg);
-      border: 1px solid var(--glass-border);
-      backdrop-filter: var(--glass-backdrop);
-      -webkit-backdrop-filter: var(--glass-backdrop);
+      background: var(--surface-dark);
+      border: 1px solid var(--border-dark);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
       border-radius: 20px;
       padding: 28px;
       margin-bottom: 32px;
@@ -158,7 +158,7 @@ export interface ActivityItem {
     }
 
     .feed-title {
-      color: var(--bg-gray-100);
+      color: var(--text-light);
       font-size: 1.5rem;
       font-weight: 700;
       margin: 0;
@@ -172,7 +172,7 @@ export interface ActivityItem {
     .filter-btn {
       background: rgba(255, 255, 255, 0.05);
       border: 1px solid rgba(255, 255, 255, 0.1);
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       padding: 8px 16px;
       border-radius: 20px;
       font-size: 0.85rem;
@@ -242,44 +242,21 @@ export interface ActivityItem {
       align-items: center;
       justify-content: center;
       font-size: 1.1rem;
-      border: 2px solid var(--glass-border);
+      border: 2px solid var(--border-dark);
       z-index: 2;
     }
 
-    .category-payment {
-      background: linear-gradient(135deg, var(--success-500), var(--success-600));
-      color: white;
-    }
-
-    .category-document {
-      background: linear-gradient(135deg, var(--info-500), var(--info-600));
-      color: white;
-    }
-
-    .category-communication {
-      background: linear-gradient(135deg, var(--primary-cyan-400), var(--primary-cyan-600));
-      color: white;
-    }
-
-    .category-opportunity {
-      background: linear-gradient(135deg, var(--accent-amber-400), var(--accent-amber-600));
-      color: var(--bg-gray-950);
-    }
-
-    .category-renewal {
-      background: linear-gradient(135deg, var(--warning-500), var(--warning-600));
-      color: white;
-    }
-
-    .category-achievement {
-      background: linear-gradient(135deg, var(--success-400), var(--success-500));
-      color: white;
-    }
+    .category-payment { background: var(--success-600); color: white; }
+    .category-document { background: var(--info-600); color: white; }
+    .category-communication { background: var(--primary-cyan-600); color: white; }
+    .category-opportunity { background: var(--accent-amber-600); color: white; }
+    .category-renewal { background: var(--warning-600); color: white; }
+    .category-achievement { background: var(--success-500); color: white; }
 
     .timeline-line {
       width: 2px;
       height: 40px;
-      background: linear-gradient(to bottom, var(--glass-border), transparent);
+      background: var(--border-dark);
       margin-top: 8px;
     }
 
@@ -327,11 +304,11 @@ export interface ActivityItem {
 
     .type-automated {
       background: rgba(156, 163, 175, 0.2);
-      color: var(--bg-gray-400);
+      color: var(--text-2);
     }
 
     .activity-time {
-      color: var(--bg-gray-400);
+      color: var(--text-2);
       font-size: 0.8rem;
     }
 
@@ -340,7 +317,7 @@ export interface ActivityItem {
     }
 
     .activity-title {
-      color: var(--bg-gray-100);
+      color: var(--text-light);
       font-size: 1rem;
       font-weight: 600;
       margin: 0 0 6px 0;
@@ -348,7 +325,7 @@ export interface ActivityItem {
     }
 
     .activity-description {
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       font-size: 0.9rem;
       line-height: 1.5;
       margin: 0 0 12px 0;
@@ -376,14 +353,14 @@ export interface ActivityItem {
     }
 
     .metadata-text {
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       font-weight: 500;
     }
 
     .suggested-action-btn {
-      background: linear-gradient(135deg, var(--accent-amber-500), var(--accent-amber-600));
-      color: var(--bg-gray-950);
-      border: none;
+      background: var(--bg-dark);
+      color: var(--text-light);
+      border: 1px solid var(--border-dark);
       padding: 8px 16px;
       border-radius: 10px;
       font-size: 0.85rem;
@@ -397,7 +374,6 @@ export interface ActivityItem {
 
     .suggested-action-btn:hover {
       transform: translateY(-1px);
-      box-shadow: 0 4px 12px rgba(245, 158, 11, 0.3);
     }
 
     .action-icon {
@@ -415,14 +391,14 @@ export interface ActivityItem {
     }
 
     .empty-title {
-      color: var(--bg-gray-200);
+      color: var(--text-2);
       font-size: 1.2rem;
       font-weight: 600;
       margin: 0 0 8px 0;
     }
 
     .empty-description {
-      color: var(--bg-gray-400);
+      color: var(--text-2);
       font-size: 0.9rem;
       margin: 0;
     }
@@ -437,7 +413,7 @@ export interface ActivityItem {
     .load-more-btn {
       background: rgba(255, 255, 255, 0.05);
       border: 1px solid rgba(255, 255, 255, 0.1);
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       padding: 12px 24px;
       border-radius: 12px;
       font-size: 0.9rem;

--- a/src/app/components/shared/next-best-action-hero/next-best-action-hero.component.ts
+++ b/src/app/components/shared/next-best-action-hero/next-best-action-hero.component.ts
@@ -130,10 +130,10 @@ export interface ActionButton {
   `,
   styles: [`
     .next-best-action-hero {
-      background: var(--glass-bg);
-      border: 1px solid var(--glass-border);
-      backdrop-filter: var(--glass-backdrop);
-      -webkit-backdrop-filter: var(--glass-backdrop);
+      background: var(--surface-dark);
+      border: 1px solid var(--border-dark);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
       border-radius: 20px;
       padding: 32px;
       margin-bottom: 32px;
@@ -148,7 +148,7 @@ export interface ActionButton {
       left: 0;
       right: 0;
       height: 4px;
-      background: linear-gradient(90deg, var(--accent-amber-500), var(--primary-cyan-400));
+      background: var(--border-dark);
       opacity: 0.8;
     }
 
@@ -217,7 +217,7 @@ export interface ActionButton {
     }
 
     .hero-subtitle {
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       font-size: 0.95rem;
       margin: 0;
       opacity: 0.9;
@@ -265,7 +265,7 @@ export interface ActionButton {
       width: 64px;
       height: 64px;
       border-radius: 50%;
-      background: linear-gradient(135deg, var(--primary-cyan-400), var(--primary-cyan-600));
+      background: var(--bg-dark);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -274,7 +274,7 @@ export interface ActionButton {
       font-size: 1.2rem;
       background-size: cover;
       background-position: center;
-      border: 3px solid var(--glass-border);
+      border: 3px solid var(--border-dark);
     }
 
     .health-score {
@@ -289,7 +289,7 @@ export interface ActionButton {
       justify-content: center;
       font-size: 0.75rem;
       font-weight: 700;
-      border: 2px solid var(--bg-gray-950);
+      border: 2px solid var(--bg-dark);
     }
 
     .health-excellent { background: var(--success-500); color: white; }
@@ -302,7 +302,7 @@ export interface ActionButton {
     }
 
     .client-name {
-      color: var(--bg-gray-100);
+      color: var(--text-light);
       font-size: 1.3rem;
       font-weight: 700;
       margin: 0 0 8px 0;
@@ -322,7 +322,7 @@ export interface ActionButton {
     }
 
     .action-description {
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       font-size: 1rem;
       line-height: 1.5;
       margin: 0;
@@ -354,7 +354,7 @@ export interface ActionButton {
     }
 
     .reasoning-text {
-      color: var(--bg-gray-200);
+      color: var(--text-2);
       font-size: 0.95rem;
       line-height: 1.6;
       margin: 0 0 16px 0;
@@ -386,7 +386,7 @@ export interface ActionButton {
     }
 
     .metric-label {
-      color: var(--bg-gray-400);
+      color: var(--text-2);
       font-size: 0.8rem;
     }
 

--- a/src/app/components/shared/risk-radar/risk-radar.component.ts
+++ b/src/app/components/shared/risk-radar/risk-radar.component.ts
@@ -412,7 +412,7 @@ export interface RiskRadarClient {
     }
 
     .issues-list li {
-      color: var(--bg-gray-300);
+      color: var(--text-2);
       font-size: 0.85rem;
       padding: 4px 0;
       padding-left: 16px;


### PR DESCRIPTION
Refactor UI components and styles to remove legacy `gray-*` classes, `glassmorphism` and `gradient` effects, and enhance the Minimal Dark audit script.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f5a4978-c47e-4496-b3e2-0a8cb18020c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6f5a4978-c47e-4496-b3e2-0a8cb18020c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

