### PR TITLE
Run code cleanup audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,9 @@
     "upgrade:ops:deliveries": "node scripts/upgrade-component.js ops-deliveries",
     "upgrade:ops:delivery-detail": "node scripts/upgrade-component.js delivery-detail",
     "upgrade:ops:triggers-monitor": "node scripts/upgrade-component.js triggers-monitor",
-    "upgrade:post-sales:client-tracking": "node scripts/upgrade-component.js client-tracking"
+    "upgrade:post-sales:client-tracking": "node scripts/upgrade-component.js client-tracking",
+    "clean:audit": "node scripts/clean-audit.js",
+    "clean:audit:fix": "node scripts/clean-audit.js --fix"
   },
   "lint-staged": {
     "*.{ts,js}": [

--- a/scripts/clean-audit.js
+++ b/scripts/clean-audit.js
@@ -1,0 +1,84 @@
+// scripts/clean-audit.js
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = "src";
+const PATTERNS = [
+  {
+    name: "TODO/FIXME/HACK/DEPRECATED",
+    regex: /(.*(TODO|FIXME|HACK|DEPRECATED).*[\r\n]*)/gi,
+  },
+  {
+    name: "console.log",
+    regex: /(.*console\\.log.*[\r\n]*)/gi,
+  },
+  {
+    name: "mocks/demos",
+    regex: /(mock|demo)/i, // Solo audita, no elimina
+  },
+];
+
+const FIX_MODE = process.argv.includes("--fix");
+
+function walk(dir, callback) {
+  fs.readdirSync(dir, { withFileTypes: true }).forEach((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, callback);
+    } else {
+      callback(fullPath);
+    }
+  });
+}
+
+function audit() {
+  console.log("🧹 Audit de Limpieza del Repo – Conductores PWA");
+  console.log("==============================================");
+
+  let issues = 0;
+
+  walk(ROOT, (file) => {
+    let content = fs.readFileSync(file, "utf8");
+    let originalContent = content;
+
+    PATTERNS.forEach(({ name, regex }) => {
+      if (regex.test(content)) {
+        if (FIX_MODE && (name.includes("TODO") || name.includes("console.log"))) {
+          content = content.replace(regex, (match) => {
+            return `// removed by clean-audit: ${match.trim()}\n`;
+          });
+          console.log(`✂️ Eliminado ${name} en: ${file}`);
+        } else {
+          console.log(`❌ ${name} encontrado en: ${file}`);
+          issues++;
+        }
+      }
+    });
+
+    if (FIX_MODE && content !== originalContent) {
+      fs.writeFileSync(file, content, "utf8");
+    }
+  });
+
+  // Archivos grandes sospechosos
+  walk(ROOT, (file) => {
+    const stats = fs.statSync(file);
+    if (stats.size > 500 * 1024) {
+      console.log(`⚠️ Archivo grande (>500KB): ${file}`);
+    }
+  });
+
+  if (!FIX_MODE) {
+    if (issues === 0) {
+      console.log("✅ No se encontraron problemas de limpieza.");
+    } else {
+      console.log(`⚠️ Se detectaron ${issues} incidencias.`);
+      process.exitCode = 1;
+    }
+  } else {
+    console.log("✅ Limpieza automática completada (modo --fix).");
+  }
+}
+
+audit();
+

--- a/scripts/clean-audit.sh
+++ b/scripts/clean-audit.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "🧹 Audit de Limpieza del Repo – Conductores PWA"
+echo "----------------------------------------------"
+
+# 1. Buscar TODO, FIXME, HACK, DEPRECATED
+echo "🔍 Buscando TODO/FIXME/HACK/DEPRECATED..."
+grep -RInE "TODO|FIXME|HACK|DEPRECATED" src/ || echo "✅ No se encontraron TODO/FIXME/HACK/DEPRECATED"
+
+# 2. Buscar console.log (no permitido en producción)
+echo
+echo "🔍 Buscando console.log..."
+grep -RIn "console\\.log" src/ || echo "✅ No se encontraron console.log"
+
+# 3. Buscar mocks y demos no usados
+echo
+echo "🔍 Buscando mocks y demos..."
+grep -RInE "mock|demo" src/app/components/ || echo "✅ No se encontraron mocks/demos"
+
+# 4. Buscar archivos de integración/demos heredados
+echo
+echo "🔍 Archivos de integración/demo que pueden ser removidos:"
+find src/app/components -iname "*integration-demo*.ts" -o -iname "*demo*.ts" || true
+
+# 5. Verificar archivos grandes >500KB (potenciales residuos)
+echo
+echo "🔍 Archivos sospechosamente grandes (>500KB):"
+find src -type f -size +500k
+
+echo
+echo "✅ Auditoría de limpieza finalizada"
+


### PR DESCRIPTION
Add a clean-up audit script to detect and optionally fix development artifacts.

This PR introduces a `clean-audit` script (Node.js and Bash) to identify and remove `TODO`s, `FIXME`s, `console.log`s, mock/demo references, and large files. The Node.js version includes a `--fix` mode (`npm run clean:audit:fix`) that automatically removes `console.log` statements and lines containing `TODO`, `FIXME`, `HACK`, or `DEPRECATED` keywords, replacing them with a `// removed by clean-audit` comment. This helps maintain a clean codebase by preventing development artifacts from reaching production.

---
<a href="https://cursor.com/background-agent?bcId=bc-11f45b6b-24b9-499a-afa2-5214af6c03a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11f45b6b-24b9-499a-afa2-5214af6c03a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

