### PR TITLE
Update cypress selectors for minimal dark theme

### DIFF
--- a/cypress/e2e/00-smoke-navigation.cy.ts
+++ b/cypress/e2e/00-smoke-navigation.cy.ts
@@ -44,8 +44,8 @@ describe('Smoke Navigation (visual + functional)', () => {
 
       // Page renders
       cy.get('body').should('be.visible');
-      // Container exists
-      cy.get('main, [role="main"], .premium-container').should('exist');
+      // Container exists (Minimal Dark)
+      cy.get('main, [role="main"], .ui-card').should('exist');
 
       // Try safe interactions: click non-destructive CTAs if present
       // Prefer data-cy primary actions

--- a/cypress/e2e/01-authentication.cy.ts
+++ b/cypress/e2e/01-authentication.cy.ts
@@ -1,11 +1,13 @@
-describe('Authentication Flow', () => {
+describe('Authentication Flow (Minimal Dark)', () => {
   beforeEach(() => {
     cy.setupDefaultIntercepts();
   });
 
   describe('Login Process', () => {
-    it('should display login form correctly', () => {
+    it('should display login form correctly (Minimal Dark)', () => {
       cy.navigateAndWait('/login');
+      // Container exists (Minimal Dark)
+      cy.get('main, [role="main"], .ui-card').should('exist');
       
       // Verify login form elements are present using enhanced commands
       cy.waitForElement('[data-cy="login-form"]');

--- a/scripts/verify-ux.sh
+++ b/scripts/verify-ux.sh
@@ -24,6 +24,9 @@ PATTERNS=(
   "bg-gradient-"
   "bg-gray-"
   "text-gray-"
+  "premium-container"
+  "theme-premium"
+  "premium-animations"
 )
 
 INCLUDE_PATHS=("src")


### PR DESCRIPTION
Remove all remaining Premium theme references from Cypress E2E tests and enforce its absence with a UX verifier.

---
<a href="https://cursor.com/background-agent?bcId=bc-494905ec-0928-4cd0-bd98-5bc1ec81ded2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-494905ec-0928-4cd0-bd98-5bc1ec81ded2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

