### PR TITLE
Check for glassmorphism backdrop blur

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -76,7 +76,7 @@
   <div class="flex-1 flex flex-col">
 
     <!-- Topbar - Enterprise Style -->
-    <header class="h-16 border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-900/80 backdrop-blur flex items-center justify-between px-6">
+    <header class="h-16 border-b border-border bg-surface flex items-center justify-between px-6">
       <div class="text-sm text-slate-600 dark:text-slate-400">
         Organización: <span class="font-medium text-slate-900 dark:text-slate-100" data-cy="org-name">mvpcoductores</span>
       </div>

--- a/src/app/components/auth/register/register.component.ts
+++ b/src/app/components/auth/register/register.component.ts
@@ -401,7 +401,7 @@ interface WizardStep {
       width: 100%;
       max-width: 600px;
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
-      backdrop-filter: blur(10px);
+      
     }
 
     .register-header {

--- a/src/app/components/auth/verify-email/verify-email.component.ts
+++ b/src/app/components/auth/verify-email/verify-email.component.ts
@@ -70,7 +70,7 @@ import { AuthService } from '../../../services/auth.service';
       width: 100%;
       max-width: 500px;
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
-      backdrop-filter: blur(10px);
+      
       text-align: center;
     }
 

--- a/src/app/components/avi-interview/avi-interview.component.scss
+++ b/src/app/components/avi-interview/avi-interview.component.scss
@@ -54,7 +54,7 @@
 
 // Interview Header and Progress
 .interview-header {
-  @apply border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-900/80 backdrop-blur;
+  @apply border-b border-border bg-surface;
 
   .progress-section {
     @apply max-w-6xl mx-auto px-6 py-4;
@@ -287,7 +287,7 @@
       }
 
       .processing-overlay {
-        @apply absolute inset-0 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm flex items-center justify-center rounded-lg;
+        @apply absolute inset-0 bg-black/60 flex items-center justify-center rounded-lg;
 
         .processing-content {
           @apply text-slate-600 dark:text-slate-400 font-medium;

--- a/src/app/components/delivery/delivery-tracker/delivery-tracker.component.css
+++ b/src/app/components/delivery/delivery-tracker/delivery-tracker.component.css
@@ -223,7 +223,6 @@
   padding: 0.5rem 0.75rem;
   border-radius: 6px;
   font-size: 0.875rem;
-  backdrop-filter: blur(10px);
 }
 
 .factor.light, .factor.clear, .factor.optimal {

--- a/src/app/components/pages/admin/admin-panel.component.html
+++ b/src/app/components/pages/admin/admin-panel.component.html
@@ -3,7 +3,7 @@
 
 <div class="min-h-screen bg-slate-50 dark:bg-slate-950">
   <!-- Header -->
-  <header class="bg-white/80 dark:bg-slate-900/80 backdrop-blur border-b border-slate-200 dark:border-slate-800 px-4 sm:px-6 py-4">
+  <header class="bg-surface border-b border-border px-4 sm:px-6 py-4">
     <div class="flex items-center justify-between">
       <div class="flex-1 min-w-0">
         <h1 class="text-xl sm:text-2xl font-semibold text-slate-900 dark:text-slate-100 mb-1 truncate">

--- a/src/app/components/pages/dashboard/dashboard.component.ts
+++ b/src/app/components/pages/dashboard/dashboard.component.ts
@@ -37,7 +37,7 @@ interface KPICard {
       <app-connection-indicator></app-connection-indicator>
 
       <!-- Header -->
-      <header class="bg-white/80 dark:bg-slate-900/80 backdrop-blur border-b border-slate-200 dark:border-slate-800 px-4 sm:px-6 py-4">
+      <header class="bg-surface border-b border-border px-4 sm:px-6 py-4">
         <div class="flex items-center justify-between">
           <div class="flex-1 min-w-0">
             <h1 class="text-xl sm:text-2xl font-semibold text-slate-900 dark:text-slate-100 mb-1 truncate">

--- a/src/app/components/pages/integraciones/integraciones.component.ts
+++ b/src/app/components/pages/integraciones/integraciones.component.ts
@@ -37,7 +37,7 @@ interface APILog {
 
     <div class="min-h-screen bg-slate-50 dark:bg-slate-950">
       <!-- Header -->
-      <header class="bg-white/80 dark:bg-slate-900/80 backdrop-blur border-b border-slate-200 dark:border-slate-800 px-4 sm:px-6 py-4">
+      <header class="bg-surface border-b border-border px-4 sm:px-6 py-4">
         <div class="flex items-center justify-between">
           <div class="flex-1 min-w-0">
             <h1 class="text-xl sm:text-2xl font-semibold text-slate-900 dark:text-slate-100 mb-1 truncate">

--- a/src/app/components/pages/proteccion/proteccion.component.html
+++ b/src/app/components/pages/proteccion/proteccion.component.html
@@ -3,7 +3,7 @@
 
 <div class="min-h-screen bg-slate-50 dark:bg-slate-950">
   <!-- Header -->
-  <header class="border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
+  <header class="border-b border-border bg-surface">
     <div class="max-w-6xl mx-auto px-6 py-4">
       <div class="flex items-center gap-4">
         <div>

--- a/src/app/components/pages/simulador/ags-ahorro/ags-ahorro.component.html
+++ b/src/app/components/pages/simulador/ags-ahorro/ags-ahorro.component.html
@@ -3,7 +3,7 @@
 
 <div class="min-h-screen bg-slate-50 dark:bg-slate-950">
   <!-- Header -->
-  <header class="border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
+  <header class="border-b border-border bg-surface">
     <div class="max-w-6xl mx-auto px-6 py-4">
       <div class="flex items-center gap-4">
         <button (click)="goBack()" class="ui-btn ui-btn-ghost ui-btn-sm" data-cy="back-button">

--- a/src/app/components/pages/simulador/edomex-individual/edomex-individual.component.html
+++ b/src/app/components/pages/simulador/edomex-individual/edomex-individual.component.html
@@ -3,7 +3,7 @@
 
 <div class="min-h-screen bg-slate-50 dark:bg-slate-950">
   <!-- Header -->
-  <header class="border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
+  <header class="border-b border-border bg-surface">
     <div class="max-w-6xl mx-auto px-6 py-4">
       <div class="flex items-center gap-4">
         <button (click)="goBack()" class="ui-btn ui-btn-ghost ui-btn-sm" data-cy="back-button">

--- a/src/app/components/pages/simulador/tanda-colectiva/tanda-colectiva.component.ts
+++ b/src/app/components/pages/simulador/tanda-colectiva/tanda-colectiva.component.ts
@@ -26,7 +26,7 @@ declare var Chart: any;
 
     <div class="min-h-screen bg-slate-50 dark:bg-slate-950">
       <!-- Header -->
-      <header class="border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
+      <header class="border-b border-border bg-surface">
         <div class="max-w-6xl mx-auto px-6 py-4">
           <div class="flex items-center gap-4">
             <button (click)="goBack()" class="ui-btn ui-btn-ghost ui-btn-sm" data-cy="back-button">

--- a/src/app/components/shared/avi-verification-modal/avi-verification-modal.component.scss
+++ b/src/app/components/shared/avi-verification-modal/avi-verification-modal.component.scss
@@ -9,7 +9,7 @@
       align-items: center;
       justify-content: center;
       z-index: 1000;
-      backdrop-filter: blur(4px);
+      
     }
 
     .avi-modal-container {

--- a/src/app/components/shared/bottom-nav-bar/bottom-nav-bar.component.ts
+++ b/src/app/components/shared/bottom-nav-bar/bottom-nav-bar.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule, Router, NavigationEnd } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { NavigationEnd, Router, RouterModule } from '@angular/router';
 import { filter } from 'rxjs/operators';
 import { environment } from '../../../../environments/environment';
 
@@ -42,8 +42,7 @@ interface BottomNavItem {
       right: 0;
       z-index: 1000;
       display: flex;
-      background: rgba(45, 55, 72, 0.95);
-      backdrop-filter: blur(20px);
+      background: var(--flat-surface-bg);
       border-top: 1px solid rgba(255, 255, 255, 0.1);
       padding: 8px 0 calc(8px + env(safe-area-inset-bottom));
       box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.1);
@@ -180,7 +179,7 @@ interface BottomNavItem {
     /* Dark mode support */
     @media (prefers-color-scheme: dark) {
       .bottom-nav-bar {
-        background: rgba(17, 24, 39, 0.95);
+        background: var(--flat-surface-bg);
         border-top: 1px solid rgba(255, 255, 255, 0.1);
       }
     }
@@ -259,7 +258,7 @@ export class BottomNavBarComponent implements OnInit {
     
     // Listen to route changes
     this.router.events.pipe(
-      filter(event => event instanceof NavigationEnd)
+      filter((event: any) => event instanceof NavigationEnd)
     ).subscribe(() => {
       this.updateActiveStates();
     });

--- a/src/app/components/shared/client-mode-toggle/client-mode-toggle.component.ts
+++ b/src/app/components/shared/client-mode-toggle/client-mode-toggle.component.ts
@@ -209,8 +209,7 @@ export type ViewMode = 'advisor' | 'client';
       right: 0;
       bottom: 0;
       background: rgba(3, 7, 18, 0.95);
-      backdrop-filter: blur(8px);
-      -webkit-backdrop-filter: blur(8px);
+      
       display: flex;
       align-items: center;
       justify-content: center;

--- a/src/app/components/shared/event-log.component.ts
+++ b/src/app/components/shared/event-log.component.ts
@@ -1,6 +1,6 @@
-import { Component, Input, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { EventLog, Actor, EventType } from '../../models/types';
+import { Component, Input, OnInit } from '@angular/core';
+import { Actor, EventLog, EventType } from '../../models/types';
 
 interface EventGroup {
   date: string;
@@ -89,7 +89,7 @@ interface EventGroup {
           <div class="event-groups space-y-8">
             <div *ngFor="let group of getEventGroups(); trackBy: trackByDate" class="event-group">
               <!-- Date Header -->
-              <div class="date-header sticky top-0 z-10 bg-neutral-900/80 backdrop-blur-sm py-3 mb-4">
+              <div class="date-header sticky top-0 z-10 bg-surface py-3 mb-4">
                 <div class="flex items-center gap-4">
                   <div class="date-marker w-4 h-4 bg-primary-cyan-500 rounded-full relative z-10 flex-shrink-0 ml-6"></div>
                   <h4 class="text-lg font-semibold text-white">{{ group.date }}</h4>
@@ -315,9 +315,8 @@ interface EventGroup {
     }
 
     .event-card {
-      background: rgba(31, 41, 55, 0.5);
-      border-color: rgba(75, 85, 99, 0.3);
-      backdrop-filter: blur(4px);
+      background: #1f2937;
+      border-color: #4b5563;
     }
 
     .event-card.payment {
@@ -391,7 +390,6 @@ interface EventGroup {
     }
 
     .date-header {
-      backdrop-filter: blur(8px);
     }
 
     @media (max-width: 768px) {

--- a/src/app/components/shared/interview-checkpoint-modal/interview-checkpoint-modal.component.ts
+++ b/src/app/components/shared/interview-checkpoint-modal/interview-checkpoint-modal.component.ts
@@ -186,7 +186,7 @@ interface CheckpointModalData {
       align-items: center;
       justify-content: center;
       z-index: 2000;
-      backdrop-filter: blur(4px);
+      
     }
 
     .checkpoint-modal {

--- a/src/app/components/shared/manual-ocr-entry/manual-ocr-entry.component.ts
+++ b/src/app/components/shared/manual-ocr-entry/manual-ocr-entry.component.ts
@@ -157,7 +157,7 @@ export interface ManualOCRData {
       align-items: center;
       justify-content: center;
       z-index: 9999;
-      backdrop-filter: blur(4px);
+      
     }
 
     .manual-entry-modal {

--- a/src/app/components/shared/next-best-action-widget/next-best-action-widget.component.ts
+++ b/src/app/components/shared/next-best-action-widget/next-best-action-widget.component.ts
@@ -135,7 +135,7 @@ import { NextBestActionService, NextBestAction, ActionInsights } from '../../../
       padding: 20px;
       box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
       border: 1px solid rgba(0, 0, 0, 0.06);
-      backdrop-filter: blur(10px);
+      
     }
 
     /* Header */

--- a/src/app/components/shared/not-found/not-found.component.ts
+++ b/src/app/components/shared/not-found/not-found.component.ts
@@ -70,7 +70,7 @@ import { RouterModule, Router } from '@angular/router';
       max-width: 500px;
       width: 100%;
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
-      backdrop-filter: blur(10px);
+      
     }
 
     .error-illustration {

--- a/src/app/components/shared/offline-indicator/offline-indicator.component.ts
+++ b/src/app/components/shared/offline-indicator/offline-indicator.component.ts
@@ -85,7 +85,7 @@ import { OfflineService } from '../../../services/offline.service';
       right: 0;
       z-index: 1000;
       padding: 12px 16px;
-      backdrop-filter: blur(8px);
+      
       border-bottom: 1px solid rgba(255, 255, 255, 0.1);
       transition: all 0.3s ease;
       animation: slideDown 0.3s ease;
@@ -206,7 +206,7 @@ import { OfflineService } from '../../../services/offline.service';
       font-size: 12px;
       font-weight: 500;
       cursor: pointer;
-      backdrop-filter: blur(8px);
+      
       border: 1px solid rgba(255, 255, 255, 0.1);
       transition: all 0.2s ease;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);

--- a/src/app/components/shared/progress-bar.component.ts
+++ b/src/app/components/shared/progress-bar.component.ts
@@ -56,7 +56,7 @@ type ProgressSize = 'sm' | 'md' | 'lg' | 'xl';
         <!-- Goal Marker (if different from max) -->
         <div 
           *ngIf="goalMarker && goal < max" 
-          class="goal-marker absolute top-0 w-0.5 h-full bg-white/80 z-10"
+          class="goal-marker absolute top-0 w-0.5 h-full bg-ink/50 z-10"
           [style.left.%]="(goal / max) * 100"
         >
           <div class="marker-tooltip absolute -top-8 left-1/2 transform -translate-x-1/2 px-2 py-1 bg-neutral-900 text-white text-xs rounded whitespace-nowrap">
@@ -339,11 +339,11 @@ export class ProgressBarComponent {
 
   getStatusMessage(): string {
     const percentage = this.getPercentage();
-    if (percentage >= 100) return '¡Objetivo completado!';
+    if (percentage >= 100) return 'ï¿½Objetivo completado!';
     if (percentage >= 80) return 'En buen camino';
     if (percentage >= 60) return 'Progreso constante';
-    if (percentage >= 40) return 'Necesita atención';
-    return 'Requiere acción urgente';
+    if (percentage >= 40) return 'Necesita atenciï¿½n';
+    return 'Requiere acciï¿½n urgente';
   }
 
   getStatusMessageClass(): string {

--- a/src/app/components/shared/pwa-install-prompt/pwa-install-prompt.component.ts
+++ b/src/app/components/shared/pwa-install-prompt/pwa-install-prompt.component.ts
@@ -1,5 +1,5 @@
-import { Component, computed, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Component, computed, signal } from '@angular/core';
 import { PwaInstallService } from '../../../services/pwa-install.service';
 
 @Component({
@@ -115,7 +115,7 @@ import { PwaInstallService } from '../../../services/pwa-install.service';
       color: white;
       padding: 16px;
       box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.1);
-      backdrop-filter: blur(8px);
+      
     }
 
     .banner-content {
@@ -168,7 +168,7 @@ import { PwaInstallService } from '../../../services/pwa-install.service';
     .install-btn.primary {
       background: rgba(255, 255, 255, 0.2);
       color: white;
-      backdrop-filter: blur(8px);
+      
     }
 
     .install-btn.primary:hover:not(:disabled) {
@@ -206,7 +206,7 @@ import { PwaInstallService } from '../../../services/pwa-install.service';
       align-items: center;
       justify-content: center;
       padding: 16px;
-      backdrop-filter: blur(4px);
+      
     }
 
     .modal-content {
@@ -349,7 +349,7 @@ import { PwaInstallService } from '../../../services/pwa-install.service';
       cursor: pointer;
       box-shadow: 0 4px 16px rgba(102, 126, 234, 0.3);
       transition: all 0.2s ease;
-      backdrop-filter: blur(8px);
+      
     }
 
     .floating-install-btn:hover {

--- a/src/app/components/shared/unauthorized/unauthorized.component.ts
+++ b/src/app/components/shared/unauthorized/unauthorized.component.ts
@@ -102,7 +102,7 @@ import { AuthService } from '../../../services/auth.service';
       max-width: 500px;
       width: 100%;
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
-      backdrop-filter: blur(10px);
+      
     }
 
     .error-illustration {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -95,6 +95,13 @@
   --state-warning: var(--accent-amber-500);
   --state-error: var(--error-500);
   --state-info: var(--primary-cyan-400);
+  /* Minimal Dark tokens */
+  --color-surface: #0b1220;
+  --color-surface-2: #0f172a;
+  --color-border: #1f2937;
+  --color-text: #e5e7eb;
+  --color-text-muted: #94a3b8;
+  --shadow-elev-1: 0 1px 2px rgba(0,0,0,.3);
 }
 
 /* ===== GLOBAL RESET & BASE STYLES ===== */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,13 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        surface: 'var(--color-surface)',
+        surface2: 'var(--color-surface-2)',
+        border: 'var(--color-border)',
+        ink: {
+          DEFAULT: 'var(--color-text)',
+          muted: 'var(--color-text-muted)'
+        },
         brand: {
           primary: '#0EA5E9',
           success: '#22C55E',
@@ -30,7 +37,8 @@ module.exports = {
         lg: '12px'
       },
       boxShadow: {
-        sm: '0 1px 2px rgba(0,0,0,0.06)',
+        none: '0 0 #0000',
+        sm: 'var(--shadow-elev-1)',
         md: '0 8px 25px rgba(0,0,0,0.10)'
       }
     }


### PR DESCRIPTION
Standardize the UI to a Minimal Dark theme by removing glassmorphism/backdrop blur effects and introducing theme tokens.

This PR centralizes theme variables (surface, border, text colors) in `src/styles.scss` and `tailwind.config.js`. It then systematically removes all instances of `backdrop-filter`, `-webkit-backdrop-filter`, and `backdrop-blur` utilities, updating headers, navbars, and modal overlays to use solid backgrounds and consistent borders defined by the new theme tokens.

---
<a href="https://cursor.com/background-agent?bcId=bc-46de9dba-5015-4a38-9f12-424d4bd874bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46de9dba-5015-4a38-9f12-424d4bd874bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

