### PR TITLE
Ajustar script de tema para evitar flash

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -40,12 +40,18 @@
   <link rel="modulepreload" href="main.js">
   <link rel="modulepreload" href="polyfills.js">
 
-  <!-- Force Dark Mode on first paint to avoid flash of light theme -->
+  <!-- Force Minimal Dark or Light Mode on first paint to avoid flash -->
   <script>
     (function(){
       try {
-        document.documentElement.classList.add('dark');
-        localStorage.setItem('darkMode', 'true');
+        var saved = localStorage.getItem('darkMode');
+        var prefersDark = window.matchMedia &&
+                          window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (saved === 'true' || (saved === null && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+        }
       } catch (e) { /* no-op */ }
     })();
   </script>


### PR DESCRIPTION
Update first-paint theme script to respect `darkMode=false` and prevent a dark theme flash for users preferring light mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-998c874d-d058-481d-b23e-62b7999ca1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-998c874d-d058-481d-b23e-62b7999ca1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

